### PR TITLE
Bugfix: Ensure coordinates are converted to FieldNumber before Point construction

### DIFF
--- a/src/cgshop2025_pyutils/verifier/verifier.py
+++ b/src/cgshop2025_pyutils/verifier/verifier.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 from cgshop2025_pyutils.data_schemas.instance import Cgshop2025Instance
 from cgshop2025_pyutils.data_schemas.solution import Cgshop2025Solution
-from cgshop2025_pyutils.geometry import Point, VerificationGeometryHelper
+from cgshop2025_pyutils.geometry import Point, VerificationGeometryHelper, FieldNumber
 
 
 class VerificationResult(BaseModel):
@@ -21,7 +21,7 @@ def verify(
     # Combine instance and solution points into one loop to simplify the logic
     all_points = [Point(x, y) for x, y in zip(instance.points_x, instance.points_y)]
     all_points.extend(
-        Point(x, y)
+        Point(FieldNumber(x), FieldNumber(y))
         for x, y in zip(solution.steiner_points_x, solution.steiner_points_y)
     )
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -113,8 +113,8 @@ def test_verify_correct_solution_extra_points():
     )
     solution = Cgshop2025Solution(
         instance_uid=instance.instance_uid,
-        steiner_points_x=[272, 320],
-        steiner_points_y=[512, 512],
+        steiner_points_x=["272/1", 320],
+        steiner_points_y=[512, "1024/2"],
         edges=[
             [0, 5],
             [5, 6],


### PR DESCRIPTION
This fix ensures that the `x` and `y` coordinates from the solution are correctly converted to `FieldNumber` instances before being passed to the `Point` constructor.